### PR TITLE
Don't create folder with the same name as the desired output

### DIFF
--- a/NUnit HTML Report Generator/Program.cs
+++ b/NUnit HTML Report Generator/Program.cs
@@ -166,10 +166,10 @@ namespace Jatech.NUnit
         /// <param name="filePath">The path to the file</param>
         private static void CreateFolder(string folderPath)
         {
-            string fullPath = Path.GetFullPath(folderPath);
-            if (!Directory.Exists(folderPath))
+            string fullPath = Path.GetDirectoryName(Path.GetFullPath(folderPath));
+            if (!Directory.Exists(fullPath))
             {
-                Directory.CreateDirectory(folderPath);
+                Directory.CreateDirectory(fullPath);
             }
         }
 


### PR DESCRIPTION
Fixes a defect where a folder with the same name as the desired output HTML was created. This would result in an `UnauthorizedAccessException` when attempting to write the output.